### PR TITLE
fix: Timeline (March - 2026)

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -414,6 +414,15 @@ const timelineRows = [
       showDate: true,
     },
     {
+      date: "Março - 2026",
+      title: "Conteúdo e documentação",
+      description:
+        "Publicação do Glossário, perguntas frequentes e outras páginas informativas no Saiba Mais. Disponibilização de relatório certificado simplificado e detalhado para uso em documentação técnica.",
+      icon: BookText,
+      active: true,
+      showDate: true,
+    },
+    {
       date: "Maio - 2026",
       title: "Relatório de Carbono Embutido",
       description:
@@ -428,15 +437,6 @@ const timelineRows = [
       description:
         "Abertura da interface de programação para integração da plataforma com sistemas externos e automação de processos.",
       icon: Code2,
-      active: false,
-      showDate: false,
-    },
-    {
-      date: "Abril - 2026",
-      title: "Conteúdo e documentação",
-      description:
-        "Publicação do Glossário, perguntas frequentes e outras páginas informativas no Saiba Mais. Disponibilização de relatório certificado simplificado e detalhado para uso em documentação técnica.",
-      icon: BookText,
       active: false,
       showDate: false,
     },


### PR DESCRIPTION
This pull request updates the timeline in `src/components/index.tsx` to reflect a new schedule for the "Conteúdo e documentação" milestone. The main change is moving this milestone from April 2026 to March 2026 and marking it as active.

**Timeline updates:**

* Changed the "Conteúdo e documentação" milestone to appear in March 2026 instead of April 2026, updated its status to active, and set `showDate` to true.
* Removed the previous "Conteúdo e documentação" milestone entry from April 2026, which was inactive and hidden.